### PR TITLE
Revert "* renamed Cvar_Get to Cvar_GetOrCreate in OS ports"

### DIFF
--- a/src/ports/android/android_main.cpp
+++ b/src/ports/android/android_main.cpp
@@ -38,9 +38,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 void Sys_Init (void)
 {
-	sys_os = Cvar_GetOrCreate("sys_os", "linux", CVAR_SERVERINFO);
-	sys_affinity = Cvar_GetOrCreate("sys_affinity", "0", CVAR_ARCHIVE);
-	sys_priority = Cvar_GetOrCreate("sys_priority", "0", CVAR_ARCHIVE, "Process nice level");
+	sys_os = Cvar_Get("sys_os", "linux", CVAR_SERVERINFO);
+	sys_affinity = Cvar_Get("sys_affinity", "0", CVAR_ARCHIVE);
+	sys_priority = Cvar_Get("sys_priority", "0", CVAR_ARCHIVE, "Process nice level");
 }
 
 /**

--- a/src/ports/linux/linux_main.cpp
+++ b/src/ports/linux/linux_main.cpp
@@ -35,9 +35,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 void Sys_Init (void)
 {
-	sys_os = Cvar_GetOrCreate("sys_os", "linux", CVAR_SERVERINFO);
-	sys_affinity = Cvar_GetOrCreate("sys_affinity", "0", CVAR_ARCHIVE);
-	sys_priority = Cvar_GetOrCreate("sys_priority", "0", CVAR_ARCHIVE, "Process nice level");
+	sys_os = Cvar_Get("sys_os", "linux", CVAR_SERVERINFO);
+	sys_affinity = Cvar_Get("sys_affinity", "0", CVAR_ARCHIVE);
+	sys_priority = Cvar_Get("sys_priority", "0", CVAR_ARCHIVE, "Process nice level");
 }
 
 /**

--- a/src/ports/macosx/osx_shared.cpp
+++ b/src/ports/macosx/osx_shared.cpp
@@ -12,7 +12,7 @@
 
 void Sys_Init (void)
 {
-	sys_os = Cvar_GetOrCreate("sys_os", "macosx", CVAR_SERVERINFO, nullptr);
-	sys_affinity = Cvar_GetOrCreate("sys_affinity", "0", CVAR_ARCHIVE, nullptr);
-	sys_priority = Cvar_GetOrCreate("sys_priority", "0", CVAR_ARCHIVE, "Process nice level");
+	sys_os = Cvar_Get("sys_os", "macosx", CVAR_SERVERINFO, nullptr);
+	sys_affinity = Cvar_Get("sys_affinity", "0", CVAR_ARCHIVE, nullptr);
+	sys_priority = Cvar_Get("sys_priority", "0", CVAR_ARCHIVE, "Process nice level");
 }

--- a/src/ports/solaris/solaris_main.cpp
+++ b/src/ports/solaris/solaris_main.cpp
@@ -48,9 +48,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 void Sys_Init (void)
 {
-	sys_os = Cvar_GetOrCreate("sys_os", "solaris", CVAR_SERVERINFO);
-	sys_affinity = Cvar_GetOrCreate("sys_affinity", "0", CVAR_ARCHIVE);
-	sys_priority = Cvar_GetOrCreate("sys_priority", "0", CVAR_ARCHIVE, "Process nice level");
+	sys_os = Cvar_Get("sys_os", "solaris", CVAR_SERVERINFO);
+	sys_affinity = Cvar_Get("sys_affinity", "0", CVAR_ARCHIVE);
+	sys_priority = Cvar_Get("sys_priority", "0", CVAR_ARCHIVE, "Process nice level");
 }
 
 int main (int argc, char **argv)


### PR DESCRIPTION
Since the function renaming was reverted but *not* in the forks directory compilation is broken on all unix-like systems.

Edit:
I forgot to create a branch for this, should I?